### PR TITLE
Only fire handler on completion of XMLHttpRequest

### DIFF
--- a/src/ajax/core.cljs
+++ b/src/ajax/core.cljs
@@ -74,6 +74,14 @@
   (-was-aborted [this]
     (= (.getLastErrorCode this) goog.net.ErrorCode/ABORT)))
 
+(defn ready-state
+  [e]
+  ({0 :not-initialized
+    1 :connection-established
+    2 :request-received
+    3 :processing-request
+    4 :response-ready} (.-readyState (.-target e))))
+
 (extend-type js/XMLHttpRequest
   AjaxImpl
   (-js-ajax-request
@@ -83,7 +91,7 @@
            timeout 0}}]
     (set! (.-timeout this) timeout)
     (set! (.-withCredentials this) with-credentials)
-    (set! (.-onreadystatechange this) #(handler this))
+    (set! (.-onreadystatechange this) #(when (= :response-ready (ready-state %)) (handler this)))
     (doto this
       (.open method uri true)
       (as-> t


### PR DESCRIPTION
The `onreadystatechange` event is fired 5 times per request,
not just on successful completion, with the following readyStates:

0: request not initialized
1: server connection established
2: request received
3: processing request
4: request finished and response is ready

We only want our success and error-handlers to be called once, on
completion of the request. So check the `readyState` of the
`XMLHttpRequest` and only call the handler if it is `4`.

This fixes issue #73.
